### PR TITLE
Remove deprecated API usage

### DIFF
--- a/lua/config/lsp/texlab.lua
+++ b/lua/config/lsp/texlab.lua
@@ -66,10 +66,7 @@ end
 
 -- ... (other helper functions like buf_cancel_build, etc. remain the same)
 local function buf_cancel_build(client, bufnr)
-    if vim.fn.has 'nvim-0.11' == 1 then
-        return client:exec_cmd({ title = 'cancel', command = 'texlab.cancelBuild' }, { bufnr = bufnr })
-    end
-    vim.lsp.buf.execute_command { command = 'texlab.cancelBuild' }
+    client:exec_cmd({ title = 'cancel', command = 'texlab.cancelBuild' }, { bufnr = bufnr })
     vim.notify('Build cancelled', vim.log.levels.INFO)
 end
 
@@ -89,21 +86,17 @@ local function command_factory(cmd)
         CancelBuild = 'texlab.cancelBuild',
     }
     return function(client, bufnr)
-        if vim.fn.has 'nvim-0.11' == 1 then
-            return client:exec_cmd({
-                title = ('clean_%s'):format(cmd),
-                command = cmd_tbl[cmd],
-                arguments = { { uri = vim.uri_from_bufnr(bufnr) } },
-            }, { bufnr = bufnr }, function(err, _)
-                if err then
-                    vim.notify(('Failed to clean %s files: %s'):format(cmd, err.message), vim.log.levels.ERROR)
-                else
-                    vim.notify(('command %s executed successfully'):format(cmd), vim.log.levels.INFO)
-                end
-            end)
-        end
-        vim.lsp.buf.execute_command { command = cmd_tbl[cmd], arguments = { { uri = vim.uri_from_bufnr(bufnr) } } }
-        vim.notify(('command %s executed successfully'):format(cmd_tbl[cmd]))
+        client:exec_cmd({
+            title = ('clean_%s'):format(cmd),
+            command = cmd_tbl[cmd],
+            arguments = { { uri = vim.uri_from_bufnr(bufnr) } },
+        }, { bufnr = bufnr }, function(err, _)
+            if err then
+                vim.notify(('Failed to clean %s files: %s'):format(cmd, err.message), vim.log.levels.ERROR)
+            else
+                vim.notify(('command %s executed successfully'):format(cmd_tbl[cmd]), vim.log.levels.INFO)
+            end
+        end)
     end
 end
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,5 +1,5 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not (vim.uv or vim.loop).fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
     local lazyrepo = "https://github.com/folke/lazy.nvim.git"
     local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
     if vim.v.shell_error ~= 0 then

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -188,13 +188,13 @@ M.config = {
 }
 
 F.configureDocAndSignature = function()
-    vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(
-        vim.lsp.handlers.signature_help, {
+    vim.lsp.handlers["textDocument/signatureHelp"] = function(...)
+        return vim.lsp.buf.signature_help({
             focusable = false,
             border = "rounded",
             zindex = 60,
-        }
-    )
+        }, ...)
+    end
     local group = vim.api.nvim_create_augroup("lsp_diagnostics_hold", { clear = true })
     vim.api.nvim_create_autocmd({ "CursorHold" }, {
         pattern = "*",
@@ -247,8 +247,12 @@ F.configureKeybinds = function()
             vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
             vim.keymap.set('n', '<leader>aw', vim.lsp.buf.code_action, opts)
             vim.keymap.set('n', '<leader>ht', ':Trouble<cr>', opts)
-            vim.keymap.set('n', '<leader>-', vim.diagnostic.goto_prev, opts)
-            vim.keymap.set('n', '<leader>=', vim.diagnostic.goto_next, opts)
+            vim.keymap.set('n', '<leader>-', function()
+                vim.diagnostic.jump({ count = -1, float = true })
+            end, opts)
+            vim.keymap.set('n', '<leader>=', function()
+                vim.diagnostic.jump({ count = 1, float = true })
+            end, opts)
         end,
     })
 end

--- a/lua/plugins/markdown.lua
+++ b/lua/plugins/markdown.lua
@@ -23,7 +23,7 @@ return {
 				endfunction
 			]])
 
-			local sysname = vim.loop.os_uname().sysname
+                        local sysname = vim.uv.os_uname().sysname
 			if sysname == 'Linux' then
 				if vim.env.SSH_CONNECTION then
 					vim.g.mkdp_browserfunc = 'EchoUrl'


### PR DESCRIPTION
## Summary
- switch to `vim.uv` instead of deprecated `vim.loop`
- replace `vim.lsp.with` usage for `signatureHelp`
- use new `vim.diagnostic.jump` calls
- rely on `Client:exec_cmd` instead of `vim.lsp.buf.execute_command`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868d900aa188329851dc7d0621e4416