### PR TITLE
Adapt lsp configuration for mason‑lspconfig v2

### DIFF
--- a/lua/config/lsp/json.lua
+++ b/lua/config/lsp/json.lua
@@ -1,5 +1,3 @@
-return {
-    setup = function(lspconfig, opts)
-        lspconfig.jsonls.setup(vim.tbl_deep_extend('force', opts or {}, {}))
-    end,
-}
+return function(opts)
+    return opts or {}
+end

--- a/lua/config/lsp/lua.lua
+++ b/lua/config/lsp/lua.lua
@@ -1,20 +1,18 @@
-return {
-    setup = function(lspconfig, opts)
-        require('neodev').setup({ lspconfig = true, override = function() end })
-        lspconfig.lua_ls.setup(vim.tbl_deep_extend('force', {
-            settings = {
-                Lua = {
-                    diagnostics = {
-                        globals = { 'vim', 'require' },
-                    },
-                    workspace = {
-                        checkThirdParty = false,
-                    },
-                    completion = {
-                        callSnippet = 'Replace',
-                    },
+return function(opts)
+    require('neodev').setup({ lspconfig = true, override = function() end })
+    return vim.tbl_deep_extend('force', {
+        settings = {
+            Lua = {
+                diagnostics = {
+                    globals = { 'vim', 'require' },
+                },
+                workspace = {
+                    checkThirdParty = false,
+                },
+                completion = {
+                    callSnippet = 'Replace',
                 },
             },
-        }, opts or {}))
-    end,
-}
+        },
+    }, opts or {})
+end

--- a/lua/config/lsp/texlab.lua
+++ b/lua/config/lsp/texlab.lua
@@ -118,40 +118,42 @@ vim.keymap.set('n', '<leader>lt', '<Cmd>TexlabToggleBuildOnSave<CR>', {
 -- =================================================================================
 -- Main configuration table
 -- =================================================================================
-return {
-    cmd = { 'texlab' },
-    filetypes = { 'tex', 'plaintex', 'bib' },
-    root_markers = { '.git', '.latexmkrc', 'latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml' },
-    settings = {
-        texlab = {
-            build = {
-                executable = 'latexmk',
-                args = { '-pdf', '-interaction=nonstopmode', '-synctex=1', '%f' },
-                -- MODIFIED: We permanently disable the server's onSave feature.
-                onSave = false,
-                forwardSearchAfter = true,
-            },
-            forwardSearch = {
-                executable = 'zathura',
-                args = { '--synctex-forward', '%l:1:%f', '%p' },
-                -- executable = 'okular',
-                -- args = { '--unique', 'file:%p#src:%l%f' },
+return function(opts)
+    local config = {
+        cmd = { 'texlab' },
+        filetypes = { 'tex', 'plaintex', 'bib' },
+        root_markers = { '.git', '.latexmkrc', 'latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml' },
+        settings = {
+            texlab = {
+                build = {
+                    executable = 'latexmk',
+                    args = { '-pdf', '-interaction=nonstopmode', '-synctex=1', '%f' },
+                    -- MODIFIED: We permanently disable the server's onSave feature.
+                    onSave = false,
+                    forwardSearchAfter = true,
+                },
+                forwardSearch = {
+                    executable = 'zathura',
+                    args = { '--synctex-forward', '%l:1:%f', '%p' },
+                    -- executable = 'okular',
+                    -- args = { '--unique', 'file:%p#src:%l%f' },
 
-                -- for windows
-                -- executable = 'SumatraPDF',
-                -- args = { '-forward-search', '%f', '%l', '%p' },
+                    -- for windows
+                    -- executable = 'SumatraPDF',
+                    -- args = { '-forward-search', '%f', '%l', '%p' },
+                },
+                -- ... (rest of your settings are fine)
+                chktex = { onOpenAndSave = false, onEdit = false },
+                diagnosticsDelay = 300,
+                latexFormatter = 'latexindent',
+                latexindent = { ['local'] = vim.fn.stdpath('config') .. '/lua/config/lsp/latexindent.yaml', modifyLineBreaks = false },
+                bibtexFormatter = 'texlab',
+                formatterLineLength = 80,
             },
-            -- ... (rest of your settings are fine)
-            chktex = { onOpenAndSave = false, onEdit = false },
-            diagnosticsDelay = 300,
-            latexFormatter = 'latexindent',
-            latexindent = { ['local'] = vim.fn.stdpath('config') .. '/lua/config/lsp/latexindent.yaml', modifyLineBreaks = false },
-            bibtexFormatter = 'texlab',
-            formatterLineLength = 80,
         },
-    },
+    }
 
-    on_attach = function(client, bufnr)
+    config.on_attach = function(client, bufnr)
         -- Your existing buffer-local commands (LspTexlabBuild, etc.)
         vim.api.nvim_buf_create_user_command(bufnr, 'LspTexlabBuild', client_with_fn(buf_build),
             { desc = 'Build the current buffer' })
@@ -187,5 +189,11 @@ return {
                 end
             end,
         })
-    end,
-}
+
+        if opts and opts.on_attach then
+            opts.on_attach(client, bufnr)
+        end
+    end
+
+    return vim.tbl_deep_extend('force', config, opts or {})
+end

--- a/lua/config/lsp/yaml.lua
+++ b/lua/config/lsp/yaml.lua
@@ -1,9 +1,5 @@
-local M = {}
-
-M.setup = function(lspconfig, opts)
-    lspconfig.yamlls.setup({
-        on_attach = opts.on_attach,
-        capabilities = opts.capabilities,
+return function(opts)
+    return vim.tbl_deep_extend('force', {
         settings = {
             redhat = { telemetry = { enabled = false } },
             yaml = {
@@ -17,7 +13,5 @@ M.setup = function(lspconfig, opts)
                 },
             },
         },
-    })
+    }, opts or {})
 end
-
-return M


### PR DESCRIPTION
## Summary
- update server specific configuration modules to return config tables
- switch lsp setup to use `vim.lsp.config` and new `automatic_enable` option

## Testing
- `nvim` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691f0058dc83298b8ef9cac0f04807